### PR TITLE
fixes werkzeug error by explicitly pinning to 0.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ boto3_type_annotations==0.3.1
 requests==2.22.0
 uuid==1.30
 transcribe @ git+https://github.com/ictlearningsciences/py-transcribe.git@1.0.0#egg=transcribe
+# explicitly pinning Werkzeug UNTIL this bug is fixed: https://github.com/jarus/flask-testing/issues/143
+Werkzeug==0.16.1


### PR DESCRIPTION
the explicit requirement for werkzeug should be removed one this issue is fixed:

https://github.com/jarus/flask-testing/issues/143